### PR TITLE
Added button text & disabled image from feedback upload

### DIFF
--- a/app/static/js/issueReporting.js
+++ b/app/static/js/issueReporting.js
@@ -107,35 +107,40 @@ function handleIssueReportClick(event){
         }
 
         // Capture a screenshot of the website
-        html2canvas(document.body).then(function(canvas){
-            var captureDataUrl = canvas.toDataURL('image/png');
+        
+        html2canvas(document.body).then(function(canvas)
+        {
+          //var captureDataUrl = canvas.toDataURL('image/png');   // Disabled until we decide if we want this functionality or not
             
-            // Create an object with the issue reporting data
-        issueReport = {
+          // Create an object with the issue reporting data
+          issueReport = 
+          {
             pageUrl: pageUrl,
             elementType: elementType,
             elementId: elementId,
             elementClass: elementClass,
             elementText: elementText,
             tableCellInfo: tableCellInfo,
-            captureDataUrl: captureDataUrl
-        };
+            //captureDataUrl: captureDataUrl                      // See line 112
+          };
 
-        // Create a formatted string for the report details
-        var reportDetails = "Page URL: " + issueReport.pageUrl + "\n" +
-                            "Element Type: " + issueReport.elementType + "\n" +
-                            "Element ID: " + issueReport.elementId + "\n" +
-                            "Element Class: " + issueReport.elementClass + "\n" +
-                            "Element Text: " + issueReport.elementText + "\n" +
-                            "Table Cell Info: " + JSON.stringify(issueReport.tableCellInfo, null, 2);
-
-            $("#reportDetails").text(reportDetails);
-
-            // Show the modal
-            $("#report-modal").modal('show');
+          // Create a formatted string for the report details
+          var reportDetails = "Page URL: " + issueReport.pageUrl + "\n" +
+                              "Element Type: " + issueReport.elementType + "\n" +
+                              "Element ID: " + issueReport.elementId + "\n" +
+                              "Element Class: " + issueReport.elementClass + "\n" +
+                              "Element Text: " + issueReport.elementText + "\n" +
+                              "Table Cell Info: " + JSON.stringify(issueReport.tableCellInfo, null, 2);
+          
+          $("#reportDetails").text(reportDetails);
+          
+          // Show the modal
+          $("#report-modal").modal('show');
             
-            exitReportingState();
+          exitReportingState();
+          
         });
+        
     }
 }
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -71,6 +71,7 @@
                                     <img width="24" height="24" src="https://img.icons8.com/fluency-systems-regular/48/webpage-click.png" alt="webpage-click"/>
                                 </button>
                                 <button id="customReportBtn" class="btn btn-outline-danger">
+                                    <span id="sendFeedbackText">Send Feedback</span>
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil-square" viewBox="0 0 16 16">
                                         <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
                                         <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5z"/>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -71,7 +71,7 @@
                                     <img width="24" height="24" src="https://img.icons8.com/fluency-systems-regular/48/webpage-click.png" alt="webpage-click"/>
                                 </button>
                                 <button id="customReportBtn" class="btn btn-outline-danger">
-                                    <span id="sendFeedbackText">Send Feedback</span>
+                                    <span id="sendFeedbackText">Provide Feedback</span>
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil-square" viewBox="0 0 16 16">
                                         <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
                                         <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5z"/>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -72,7 +72,7 @@
                                 </button>
                                 <button id="customReportBtn" class="btn btn-outline-danger">
                                     <span id="sendFeedbackText">Provide Feedback</span>
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil-square" viewBox="0 0 16 16">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" class="bi bi-pencil-square" viewBox="0 0 16 16">
                                         <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
                                         <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5z"/>
                                     </svg>


### PR DESCRIPTION
Temporarily disabled generation of images with feedback reports, due to issues with overhead on report file sizes. Upon review, we realized we were already gathering all the information we needed to respond to reports, so until we have a better system in place, images are currently undesirable.

Also added text to the feedback button already on SDS to clarify its existence as a separate button on the page.