### PR TITLE
Fixes for Report Issue and Provide Feedback buttons

### DIFF
--- a/app/static/js/alerts.js
+++ b/app/static/js/alerts.js
@@ -1,15 +1,42 @@
-export function showAlert(alertMsg, alertType){
-    $("#alert-div").append(
+/*/////////////////////////////////////////////////
+    Display a Bootstrap Alert Message on webpage //
+    Args:                                        //
+        alertMsg: Message to be Displayed        //
+        alertType: Type of Alert                 //
+*//////////////////////////////////////////////////
+export function showAlert(alertMsg, alertType)
+{
+    $("#alert-div").append(     // Appends new alert to html element with ID: alert-div
         `<div class="alert alert-${alertType} alert-dismissible fade show" id="alert" role="alert">
             ${alertMsg}
             <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                 <span aria-hidden="true">&times;</span>
             </button>
         </div>`
+        // Dynamic Bootstrap Alert based on ${alertType}
+        // alert-dismissible: allows alert to be closed
+        // fade show: Fade-in effect on appearance
+        // ${alertMsg}: Inserts message into the alert div
+        // <button type>: Creates a button to manually close the alert
+        // <span>: Creates the (x)
     )
-    $("#alert").fadeTo(2000, 500).slideUp(1000, function(){
-        $("#alert").slideUp(1000);
-        $("#alert").alert('close')
-    });
-    $('html,body').animate({scrollTop:0},'fast')
+    /* Previous functionality, no longer required, but kept here in case we want this again later
+
+    $("#alert").fadeTo(10000, 500).slideUp(1000, function()
+        // fadeTo(10000, 500): After 10 seconds, fade to 50% opacity
+        // slideUp(1000, function(){...}):
+        {
+            $("#alert").slideUp(1000);  // Alert Div shrinks upward in 1 second
+            $("#alert").alert('close')  // Closes the Alert
+        });
+    */
+    $('html,body').animate({scrollTop:0},'slow')    // Snaps the Page to the Top (Presumably to see the alert)
+}
+
+/*/////////////////////////////////////
+    Hide Alert when no longer needed //
+*//////////////////////////////////////
+export function hideAlert()
+{
+    $("#alert").alert('close')
 }

--- a/app/static/js/issueReporting.js
+++ b/app/static/js/issueReporting.js
@@ -105,10 +105,10 @@ function exitReportingState()
 function handleIssueReportClick(event)
 // Behavior of 'Report Issue' Button
 {
+  event.preventDefault();   // Prevents the default behavior of what is clicked (in this case, preventing links from being opened while in 'Reporting' State)
   if (selectedElement.tagName.toLowerCase() == 'td')  // If Targeted Element is a valid cell in the Table
   {
     event.stopPropagation();  // Prevents Event Propagation, meaning one Event (in this case, clicking) will not trigger other Event Listeners
-    event.preventDefault();   // Prevents the default behavior of what is clicked (in this case, preventing links from being opened while in 'Reporting' State)
     $('body').off('mousemove', handleMouseMove); // Disable 'handleMouseMove' event (i.e. Stop drawing outline/don't update Target)
 
     // Capture Cell Metadata

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -43,11 +43,6 @@
                 <div style="height: auto;">
                     <div class="row">
                         <div class="col">
-                            <div id="alert-div"></div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col">
                             {%block page_title %}
                             {#page title is added here#}
                             {% endblock%}
@@ -70,8 +65,8 @@
                                     <span id="reportIssueText">Report Issue</span> 
                                     <img width="24" height="24" src="https://img.icons8.com/fluency-systems-regular/48/webpage-click.png" alt="webpage-click"/>
                                 </button>
-                                <button id="customReportBtn" class="btn btn-outline-danger">
-                                    <span id="sendFeedbackText">Provide Feedback</span>
+                                <button id="provideFeedbackBtn" class="btn btn-outline-danger">
+                                    <span id="provideFeedbackText">Provide Feedback</span>
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" class="bi bi-pencil-square" viewBox="0 0 16 16">
                                         <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
                                         <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5z"/>
@@ -80,6 +75,11 @@
                             </div>
                         </div>
                         <br>
+                    </div>
+                    <div class="row">
+                        <div class="col">
+                            <div id="alert-div" style="text-align: center;"></div>
+                        </div>
                     </div>
                     <div class="row">
                         <div class="col-md-6" id="app_content">

--- a/app/templates/feedbackModal.html
+++ b/app/templates/feedbackModal.html
@@ -1,0 +1,23 @@
+<div id="feedback-modal" class="modal modal_search"  tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 id="feedback-modal-title" class="modal-title">Feedback</h5>
+          <button type="button" class="close" data-dismiss="modal">&times;</button>
+        </div>
+        <div id="feedbackBody" class="modal-body">
+          <p>Please provide any feedback you have for the team regarding the Software Documentation Service:</p>
+          <form>
+            <div class="form-group">
+                <label for="provideFeedback">Feedback:</label>
+                <textarea class="form-control" id="provideFeedback" rows="3"></textarea>
+            </div>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-primary" id="sendFeedbackBtn">Send Feedback</button>
+        </div>
+      </div>
+    </div>
+</div>

--- a/app/templates/reportModal.html
+++ b/app/templates/reportModal.html
@@ -6,7 +6,7 @@
           <button type="button" class="close" data-dismiss="modal">&times;</button>
         </div>
         <div id="reportBody" class="modal-body">
-          <p>Please describe the issue:</p>
+          <p>Please describe the issue you're having with the Software Documentation Service:</p>
           <form>
             <div class="form-group">
                 <label for="reportFeedback">Feedback:</label>

--- a/app/templates/software_search.html
+++ b/app/templates/software_search.html
@@ -58,4 +58,5 @@
     
 {% include 'useCase.html' %}
 {% include 'reportModal.html' %}
+{% include 'feedbackModal.html' %}
 {%endblock%}


### PR DESCRIPTION
1. Updated var columnName to properly parse out 'th' header.
2. Updated handleMouuseMove to only update on valid table cells.
3. Added hideAlert() function to dismiss alert when it's no longer needed.
4. Moved 'alert-div' underneath the 'Report' button and center-aligned text.
5. Updated showAlert() to no longer control dismissing the alert. See hideAlert().
6. Updated handelIssueReportClick() to only preventDefault() for table cells.
7. Cleaned up leftover code that was erroneously causing unwanted behavior.
8. Updated handleIssueReportClick() to properly preventDefault(), was previously inside a separate event listener along with stopPropagation(), which kept it from working.
9. Created 'feedbackModal.html' as a separate modal for user feedback.
10. Updated 'reportBody' and created 'feedbackBody' to provide more verbose instructions.
11. 'alert.js' and 'issueReporting.js' are now extensively documented (please double-check for errors)
12. Mostly cleaning up code and tidying up behavior that didn't do anything.

This PR resolves #27 